### PR TITLE
Bugfix when getting playlist data

### DIFF
--- a/SoundCloud.NET/Playlist.cs
+++ b/SoundCloud.NET/Playlist.cs
@@ -57,10 +57,10 @@ namespace SoundCloud.NET
         public string Description { get; set; }
 
         [DataMember(Name = "streamable")]
-        public bool Streamabale { get; set; }
+        public bool? Streamabale { get; set; }
 
         [DataMember(Name = "downloadable")]
-        public bool Downloadable { get; set; }
+        public bool? Downloadable { get; set; }
 
         [DataMember(Name = "genre")]
         public string Genre { get; set; }


### PR DESCRIPTION
Sometimes `Serializable` and `Streamable` can be null - which causes the json serializer to crash because `Bool` can't be null...
